### PR TITLE
CameraSwitch and CameraSplit are not visible when one camera

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
@@ -234,8 +234,13 @@ public class FullScreenActivity extends AppCompatActivity {
 
                 mCameraRecord.setVisibility(View.VISIBLE);
                 mCameraPicture.setVisibility(View.VISIBLE);
-                mCameraSwitch.setVisibility(View.VISIBLE);
-                mCameraSplit.setVisibility(View.VISIBLE);
+                if (numOfCameras == 1) {
+                    mCameraSwitch.setVisibility(View.GONE);
+                    mCameraSplit.setVisibility(View.GONE);
+                } else {
+                    mCameraSwitch.setVisibility(View.VISIBLE);
+                    mCameraSplit.setVisibility(View.VISIBLE);
+                }
                 mCamera.createCameraPreview();
             }
         });


### PR DESCRIPTION
Solution : Multi-Camera show surveillance and flip button
with one camera.

Tracked-On: OAM-99435
Signed-off-by: Yang,JunchaoX <junchaox.yang@intel.com>