### PR TITLE
Issue Detailed: suw_partner_config_build is defined null in SetupWiza…

### DIFF
--- a/setupwizard/Android.bp
+++ b/setupwizard/Android.bp
@@ -1,0 +1,22 @@
+android_app {
+    name: "IntelSetupWizard",
+
+    srcs: ["src/**/*.java"],
+    resource_dirs: ["res"],
+
+    certificate: "platform",
+    privileged: true,
+    system_ext_specific: true,
+    platform_apis: true,
+
+    overrides: ["SetupWizard"],
+
+    static_libs: [
+        "androidx.activity_activity",
+        "SettingsLib",
+        "setupcompat",
+        "setupdesign",
+        "SystemUISharedLib",
+    ],
+
+}

--- a/setupwizard/AndroidManifest.xml
+++ b/setupwizard/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.intel.setupwizard">
+    <permission android:name="com.google.android.car.setupwizard.PARTNER_SETUP" android:protectionLevel="signatureOrSystem"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <application android:theme="@android:style/Theme.NoDisplay" android:label="@string/app_name"  android:directBootAware="true" android:appComponentFactory="androidx.core.app.CoreComponentFactory">
+        <receiver android:name="com.intel.car.setupwizard.PartnerReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.car.setupwizard.action.PARTNER_CUSTOMIZATION"/>
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/setupwizard/res/values/strings.xml
+++ b/setupwizard/res/values/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2018 The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<resources>
+    <!-- Application name -->
+    <string name="app_name">Intel setup wizard</string>
+    <string name="suw_partner_config_build">1.2.1849.release</string>
+</resources>

--- a/setupwizard/src/com/intel/setupwizard/PartnerReceiver.java
+++ b/setupwizard/src/com/intel/setupwizard/PartnerReceiver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.car.setupwizard;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * This is not a real receiver, but only used as a marker interface so that Setup Wizard can resolve
+ * this package and fetch resources from here.
+ *
+ * Partners should include a copy of this receiver in their package and in their manifest in order
+ * to override custom resources in the setup wizard.
+ */
+public class PartnerReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+    }
+}


### PR DESCRIPTION
…rdCarPrbuilt.apk and system has not a setupwizard partner app

Fix Detailed:  adding a intel setupwizard app, define the suw_partner_config_build in the app

Tested-On: Passed the failed ATS case.

Tracked-On: OAM-118888
Change-Id: I8168acf97569ae2f8ca6c4e83a77410161909800