### PR TITLE
Ignore extra cameras to ensure the multi preview

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
@@ -223,15 +223,18 @@ public class MultiViewActivity extends AppCompatActivity {
             manageTopLeftCam();
             manageBotmLeftCam();
             manageTopRightCam();
-        } else if (numOfCameras == 4) {
+        } else if (numOfCameras >= 4) {
             LinLayout1.setVisibility(View.VISIBLE);
             LinLayout2.setVisibility(View.VISIBLE);
             manageTopLeftCam();
             manageTopRightCam();
             manageBotmLeftCam();
             manageBotmRightCam();
+            if (numOfCameras > 4) {
+                Log.w(TAG, "numOfCameras exceeds 4. Cameras beyond the fourth will be ignored.");
+            }
         } else {
-            Log.d(TAG, "onResume No CAMERA CONNECTED");
+            Log.w(TAG, "onResume No CAMERA CONNECTED");
         }
     }
     private void set_FrameVisibilities() {


### PR DESCRIPTION
Issue Detailed: Fail to open 6 default virtio-camera with multi preview in aaag.

Issue Fixed: The multi camera app only supports up to 4 cameras. If the number of cameras exceeds 4, the extra cameras will be ignored and only the first four will be used.

Tests Done: Multi-camera preview works well after the change.

Tracked-On: OAM-128468