### PR TITLE
Mutlicam app should not access the cameraID >= 50

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
@@ -47,6 +47,8 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+import java.util.List;
+import java.util.ArrayList;
 
 import java.io.File;
 import java.util.Optional;
@@ -291,7 +293,7 @@ public class FullScreenActivity extends AppCompatActivity {
                         mCamera.getmRecord().showRecordingUI(false);
                         mCamera.getmPhoto().showVideoThumbnail();
 
-                        
+
                         if (numOfCameras > 1) {
                             mCameraSwitch.setVisibility(View.VISIBLE);
                             mCameraSplit.setVisibility(View.VISIBLE);
@@ -356,13 +358,25 @@ public class FullScreenActivity extends AppCompatActivity {
         CameraManager manager = (CameraManager)getSystemService(Context.CAMERA_SERVICE);
 
         try {
-            CameraIds = manager.getCameraIdList();
-            numOfCameras = manager.getCameraIdList().length;
+            String[] allCameraIds = manager.getCameraIdList();
+            List<String> validCameraIds = new ArrayList<>();
+
+            for (String cameraId : allCameraIds) {
+                if (Integer.parseInt(cameraId) < 50) {
+                    validCameraIds.add(cameraId);
+                    Log.v(TAG, "Get camera : " + cameraId);
+                } else {
+                    Log.v(TAG, "Skipping camera with ID >= 50: " + cameraId);
+                }
+            }
+
+            CameraIds = validCameraIds.toArray(new String[0]);
+            numOfCameras = CameraIds.length;
             if (numOfCameras == 0) {
                 Toast.makeText(FullScreenActivity.this, "No camera found closing the application",
                     Toast.LENGTH_LONG).show();
             }
-            Log.d(TAG, "Get total number of cameras present: " + manager.getCameraIdList().length);
+            Log.v(TAG, "Get total number of cameras present: " + numOfCameras);
         } catch (CameraAccessException e) {
             e.printStackTrace();
         }

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
@@ -40,6 +40,8 @@ import androidx.core.app.ActivityCompat;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.Objects;
+import java.util.List;
+import java.util.ArrayList;
 
 public class MultiViewActivity extends AppCompatActivity {
     private static final String TAG = "MultiViewActivity";
@@ -307,13 +309,25 @@ public class MultiViewActivity extends AppCompatActivity {
         CameraManager manager = (CameraManager)getSystemService(Context.CAMERA_SERVICE);
 
         try {
-            CameraIds = manager.getCameraIdList();
-            numOfCameras = manager.getCameraIdList().length;
+            String[] allCameraIds = manager.getCameraIdList();
+            List<String> validCameraIds = new ArrayList<>();
+
+            for (String cameraId : allCameraIds) {
+                if (Integer.parseInt(cameraId) < 50) {
+                    validCameraIds.add(cameraId);
+                    Log.v(TAG, "Get camera : " + cameraId);
+                } else {
+                    Log.v(TAG, "Skipping camera with ID >= 50: " + cameraId);
+                }
+            }
+
+            CameraIds = validCameraIds.toArray(new String[0]);
+            numOfCameras = CameraIds.length;
             if (numOfCameras == 0) {
                 Toast.makeText(MultiViewActivity.this, "No camera found closing the application",
                         Toast.LENGTH_LONG).show();
             }
-            Log.d(TAG, "Get total number of cameras present: " + manager.getCameraIdList().length);
+            Log.v(TAG, "Get total number of cameras present: " + numOfCameras);
         } catch (CameraAccessException e) {
             e.printStackTrace();
         }

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
@@ -40,6 +40,8 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
+import java.util.List;
+import java.util.ArrayList;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -342,13 +344,25 @@ public class SingleCameraActivity extends AppCompatActivity {
         CameraManager manager = (CameraManager)getSystemService(Context.CAMERA_SERVICE);
 
         try {
-            CameraIds = manager.getCameraIdList();
-            numOfCameras = manager.getCameraIdList().length;
+            String[] allCameraIds = manager.getCameraIdList();
+            List<String> validCameraIds = new ArrayList<>();
+
+            for (String cameraId : allCameraIds) {
+                if (Integer.parseInt(cameraId) < 50) {
+                    validCameraIds.add(cameraId);
+                    Log.v(TAG, "Get camera : " + cameraId);
+                } else {
+                    Log.v(TAG, "Skipping camera with ID >= 50: " + cameraId);
+                }
+            }
+
+            CameraIds = validCameraIds.toArray(new String[0]);
+            numOfCameras = CameraIds.length;
             if (numOfCameras == 0) {
                 Toast.makeText(SingleCameraActivity.this, "No camera found, closing the application",
                     Toast.LENGTH_LONG).show();
             }
-            Log.d(TAG, "Get total number of cameras present: " + manager.getCameraIdList().length);
+            Log.v(TAG, "Get total number of cameras present: " + numOfCameras);
         } catch (CameraAccessException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Issue Detailed: Mutlicam app should not access the cameraID >= 50

Issue Fixed: When initializing cameras in FullScreenActivity, MultiViewActivity, and SingleCameraActivity, cameras with IDs
 greater than or equal to 50 are ignored.

Tests Done: MultiCameraApp works well.

Tracked-On: OAM-131675