### PR TITLE
Fix for Incorrect Camera Resolution selection on Switch Camera

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/CameraBase.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/CameraBase.java
@@ -138,7 +138,7 @@ public class CameraBase  {
 
         mPhoto = new PhotoPreview(activity, roundedThumbnailView, cameraId);
         mRecord = new VideoRecord(this, Video_key,cameraId, mtextureView, mActivity,
-            RecordingTimeView, SettingsKey);
+            RecordingTimeView, SettingsKey, Capture_Key);
 
         mCameraBase = this;
         mCaptureImageReader = null;
@@ -515,22 +515,12 @@ public class CameraBase  {
                 mRecord.stopRecordingVideo();
             }
             mRecord.closePreviewSession();
-            try {
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (null != mCameraDevice) {
-                            //mCameraDevice.wait(200);
-                            mCameraDevice.close();
-                            mCameraDevice = null;
-                        }
-                    }
-                }).start();
-            } catch (Exception e) {
-                System.out.println(TAG +" camera close exception");
+
+            if (null != mCameraDevice) {
+                //mCameraDevice.wait(200);
+                mCameraDevice.close();
+                mCameraDevice = null;
             }
-
-
             mRecord.releaseMedia();
 
         } catch (Exception e) {

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/SurfaceUtil.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/SurfaceUtil.java
@@ -43,7 +43,7 @@ public class SurfaceUtil {
 
         egl.eglMakeCurrent(display, surface, surface, context);
 
-        GLES20.glClearColor(0, 0, 1, 0);
+        GLES20.glClearColor(0, 0, 0, 1);
         GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
 
         egl.eglSwapBuffers(display, surface);

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java
@@ -87,7 +87,7 @@ public class VideoRecord implements MediaRecorder.OnErrorListener, MediaRecorder
     private Size previewSize;
     private long mRecordingStartTime;
     private TextView mRecordingTimeView;
-    private String mVideoKey, mSettingsKey;
+    private String mVideoKey, mSettingsKey, mCaptureKey;
     private Uri mVideoUri;
 
     private CameraBase mCameraBase;
@@ -98,13 +98,14 @@ public class VideoRecord implements MediaRecorder.OnErrorListener, MediaRecorder
 
     public VideoRecord(CameraBase cameraBase, String videoKey, String cameraId,
             AutoFitTextureView textureView, Activity activity, TextView recordingView,
-            String settingsKey) {
+            String settingsKey, String captureKey) {
         mCameraBase = cameraBase;
         mTextureView = textureView;
         mActivity = activity;
         mVideoKey = videoKey;
         mCameraId = cameraId;
         mSettingsKey = settingsKey;
+        mCaptureKey = captureKey;
         previewSize = SIZE_720P;
         mRecordingTimeView  = recordingView;
         mRecordingTimeCountsDown = false;
@@ -224,9 +225,11 @@ public class VideoRecord implements MediaRecorder.OnErrorListener, MediaRecorder
             int quality = SettingsPrefUtil.getFromSetting(videoQuality);
 
             mProfile = CamcorderProfile.get(0, quality);
-
             mDimensions = new Size(mProfile.videoFrameWidth, mProfile.videoFrameHeight);
 
+        } else {
+            mDimensions = SettingsPrefUtil.sizeFromSettingString(
+                    settings.getString(mCaptureKey,"1280x720"));
         }
 
         return mDimensions;


### PR DESCRIPTION
When Switch Camera is pressed the previous session camera is closed in parallel which is reulting in surface clear failure due to surfacetexture dimensions being changed when other camera is opened and resulting in previous camera last frame displayed with different resolution before switching to new camera

Closed the camera in sequence inorder to clear the surface before starting new camera and After VideoRecord selected camera preview as per capture key resolution

Tracked-On: OAM-127549