### PR TITLE
Remove Killing App Process on app going to background

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
@@ -455,7 +455,5 @@ public class FullScreenActivity extends AppCompatActivity {
     protected void onStop() {
         super.onStop();
         Log.v(TAG, "onStop");
-        if(isSwitchingActivity == false && numOfCameras > 2)
-            System.exit(0);
-        }
     }
+}

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
@@ -707,8 +707,6 @@ public class MultiViewActivity extends AppCompatActivity {
     protected void onStop() {
         super.onStop();
         Log.v(TAG, "onStop");
-	if(isSwitchingActivity == false)
-	System.exit(0);
     }
 
     public void settingView(View view) {

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
@@ -443,7 +443,5 @@ public class SingleCameraActivity extends AppCompatActivity {
     protected void onStop() {
         super.onStop();
         Log.v(TAG, "onStop");
-        if(isSwitchingActivity == false && numOfCameras > 2)
-            System.exit(0);
-        }
     }
+}


### PR DESCRIPTION
Multicamera app was killed onStop to prevent blue screen issue occurring due to previous session close in progress

Previous Session Close in progress is handled in sequence and egl screen is set to black instead of blue to avoid blue screen issue

Tracked-On: OAM-132634